### PR TITLE
Added utils to setup, provided example test

### DIFF
--- a/src/test/js/pappu.test.js
+++ b/src/test/js/pappu.test.js
@@ -1,4 +1,4 @@
-mit = require("../../../testSetup");
+mit = require("../../../testSetup").mit;
 
 test('updateFlyFrameCountTest', () => {
   mit.Pappu.updateFlyFrameCount();

--- a/src/test/js/utils.test.js
+++ b/src/test/js/utils.test.js
@@ -1,0 +1,10 @@
+utils = require("../../../testSetup").utils;
+
+test('randomNumber', () => {
+  var result;
+  for (let i = 0; i < 100; i++) {
+    result = utils.randomNumber(1, 10);
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(result).toBeLessThanOrEqual(10);
+  }
+}); 

--- a/testSetup.js
+++ b/testSetup.js
@@ -24,6 +24,8 @@ dom.window.eval(pappu.toString());
 dom.window.eval(pakia.toString());
 dom.window.eval(main.toString());
 //dom.window.eval(loader.toString()); // not included due to error contacting the non-existent server
-mit = dom.window.mit;
 
-module.exports = mit;
+module.exports = {
+  mit: dom.window.mit, 
+  utils: dom.window.utils
+};


### PR DESCRIPTION
This should allow testing that requires access to the utils object of the window (whereas previously only the mit object was supported)